### PR TITLE
Fix multimap causing spells not to cast

### DIFF
--- a/Source/Framework/Collections/MultiMap.cs
+++ b/Source/Framework/Collections/MultiMap.cs
@@ -195,7 +195,7 @@ namespace System.Collections.Generic
             }
         }
 
-        public IEnumerable<TKey> Keys => _interalStorage.Keys.Where(k => KeysRemoved.Contains(k));
+        public IEnumerable<TKey> Keys => _interalStorage.Keys.Where(k => !KeysRemoved.Contains(k));
 
         public IEnumerable<TValue> Values
         {
@@ -246,6 +246,21 @@ namespace System.Collections.Generic
                 ValuesRemoved.Clear();
                 _completing = false;
             }
+        }
+
+        public KeyValuePair<TKey, TValue> GetFirst()
+        {
+            var firstKey = _interalStorage.FirstOrDefault();
+
+            if (firstKey.Value != null)
+            {
+                var firstVal = firstKey.Value.FirstOrDefault();
+
+                if (firstVal != null)
+                    return new KeyValuePair<TKey, TValue>(firstKey.Key, firstVal);
+            }
+
+            return default;
         }
 
         public void Clear()

--- a/Source/Framework/Collections/MultiMapEnumerator.cs
+++ b/Source/Framework/Collections/MultiMapEnumerator.cs
@@ -23,6 +23,7 @@ namespace System.Collections.Generic
 
         public void Dispose()
         {
+            _map.ItteratingComplete();
             _keyEnumerator = null;
             _valueEnumerator = null;
             _map = null;
@@ -36,7 +37,6 @@ namespace System.Collections.Generic
                     while (true)
                         if (!_keyEnumerator.MoveNext())
                         {
-                            _map.ItteratingComplete();
                             return false;
                         }
                         else if (!_map.KeysRemoved.Contains(_keyEnumerator.Current))

--- a/Source/Framework/Dynamic/EventMap.cs
+++ b/Source/Framework/Dynamic/EventMap.cs
@@ -167,7 +167,7 @@ namespace Framework.Dynamic
         {
             while (!Empty())
             {
-                var pair = _eventMap.FirstOrDefault();
+                var pair = _eventMap.GetFirst();
 
                 if (pair.Key > _time)
                 {

--- a/Source/Framework/Dynamic/EventSystem.cs
+++ b/Source/Framework/Dynamic/EventSystem.cs
@@ -26,7 +26,7 @@ namespace Framework.Dynamic
             // main event loop
             KeyValuePair<ulong, BasicEvent> i;
 
-            while ((i = _events.FirstOrDefault()).Value != null && i.Key <= _time)
+            while ((i = _events.GetFirst()).Value != null && i.Key <= _time)
             {
                 var Event = i.Value;
                 _events.Remove(i);

--- a/Source/Game/Maps/Map.cs
+++ b/Source/Game/Maps/Map.cs
@@ -5429,7 +5429,7 @@ namespace Game.Maps
                 }
 
                 _scriptSchedule.Remove(iter);
-                iter = _scriptSchedule.FirstOrDefault();
+                iter = _scriptSchedule.GetFirst();
                 Global.MapMgr.DecreaseScheduledScriptCount();
             }
         }


### PR DESCRIPTION
Multi map enumerator was not disposing properly to clear the remove queue. 

Added new GetFirst to more efficiently get the first item in the multimap. father than use a new enumerator.